### PR TITLE
Handle duplicated dimensions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,9 @@
 name = "ProportionalFitting"
 uuid = "3c40d49d-59d4-4b5d-adaa-75a7fbc8c64f"
-authors = ["Erik-Jan van Kesteren <erikjanvankesteren@pm.me>"]
+authors = [
+    "Erik-Jan van Kesteren <erikjanvankesteren@pm.me>",
+    "James Alster <jamesalster2@gmail.com>"
+]
 version = "0.3.1"
 
 [deps]

--- a/src/ArrayFactors.jl
+++ b/src/ArrayFactors.jl
@@ -82,9 +82,16 @@ function Base.show(io::IO, AF::ArrayFactors)
 end
 
 function Base.size(AF::ArrayFactors)
-    sizes = vcat(collect.(size.(AF.af))...)
-    order = sortperm(vcat(AF.di.idx...))
-    return Tuple(sizes[order])
+    dimension_sizes = [Vector{Int}() for i in 1:ndims(AF.di)]
+    for i in 1:length(AF.af)
+        for (j, d) in enumerate(AF.di.idx[i])
+            push!(dimension_sizes[d], size(AF.af[i], j))
+        end
+    end
+    if !all(allequal, dimension_sizes)
+        throw(DimensionMismatch("Dimension sizes not equal"))
+    end
+    return Tuple(first.(dimension_sizes))
 end
 
 Base.length(AF::ArrayFactors) = length(AF.af)

--- a/src/ArrayFactors.jl
+++ b/src/ArrayFactors.jl
@@ -64,8 +64,11 @@ struct ArrayFactors{T}
                 new_size = size(af[i], j)
                 if dimension_sizes[d] == 0 
                     dimension_sizes[d] = new_size
-                else # check
-                    dimension_sizes[d] == new_size || throw(DimensionMismatch("Dimension sizes not equal for dimension $d: $(dimension_sizes[d]) and $new_size"))
+                    continue
+                end
+                # check
+                if dimension_sizes[d] != new_size
+                    throw(DimensionMismatch("Dimension sizes not equal for dimension $d: $(dimension_sizes[d]) and $new_size"))
                 end
             end
         end

--- a/src/ArrayFactors.jl
+++ b/src/ArrayFactors.jl
@@ -55,9 +55,8 @@ struct ArrayFactors{T}
     di::DimIndices
     size::Tuple
 
-    #loop to check dimension sizes
     function ArrayFactors(af::Vector{<:AbstractArray{T}}, di::DimIndices) where T
-        #loop over arrays then dimensions to get size, checking for mismatches
+        # loop over arrays then dimensions to get size, checking for mismatches
         dimension_sizes = zeros(Int, ndims(di))
         for i in 1:length(af)
             for (j, d) in enumerate(di.idx[i])
@@ -72,8 +71,8 @@ struct ArrayFactors{T}
                 end
             end
         end
+        end
         return new{T}(af, di, Tuple(dimension_sizes))
-    end
 end
 
 # Constructor for mixed-type arrayfactors needs promotion before construction

--- a/src/ArrayFactors.jl
+++ b/src/ArrayFactors.jl
@@ -71,8 +71,8 @@ struct ArrayFactors{T}
                 end
             end
         end
-        end
         return new{T}(af, di, Tuple(dimension_sizes))
+    end
 end
 
 # Constructor for mixed-type arrayfactors needs promotion before construction

--- a/src/ArrayMargins.jl
+++ b/src/ArrayMargins.jl
@@ -119,7 +119,7 @@ function isconsistent(AM::ArrayMargins; tol::Float64 = eps(Float64))
 end
 
 function proportion_transform(AM::ArrayMargins)
-    mar = convert.(Vector{Float64}, AM.am) ./ sum.(AM.am)
+    mar = convert.(Array{Float64}, AM.am) ./ sum.(AM.am)
     return ArrayMargins(mar, AM.di)
 end
 

--- a/src/ArrayMargins.jl
+++ b/src/ArrayMargins.jl
@@ -96,13 +96,21 @@ function Base.show(io::IO, AM::ArrayMargins)
         show(io, AM.am[i])
     end
 end
+
 function Base.size(AM::ArrayMargins)
-    sizes = vcat(collect.(size.(AM.am))...)
-    order = sortperm(vcat(AM.di.idx...))
-    return Tuple(sizes[order])
+    dimension_sizes = [Vector{Int}() for i in 1:ndims(AM.di)]
+    for i in 1:length(AM.am)
+        for (j, d) in enumerate(AM.di.idx[i])
+            push!(dimension_sizes[d], size(AM.am[i], j))
+        end
+    end
+    if !all(allequal, dimension_sizes)
+        throw(DimensionMismatch("Dimension sizes not equal"))
+    end
+    return Tuple(first.(dimension_sizes))
 end
 Base.length(AM::ArrayMargins) = length(AM.am)
-Base.ndims(AM::ArrayMargins) = sum(ndims.(AM.am))
+Base.ndims(AM::ArrayMargins) = ndims(AM.di)
 
 # methods for consistency of margins
 function isconsistent(AM::ArrayMargins; tol::Float64 = eps(Float64))

--- a/src/ArrayMargins.jl
+++ b/src/ArrayMargins.jl
@@ -157,13 +157,13 @@ end
 
 function margin_totals_match(AM::ArrayMargins; tol::Float64 = eps(Float64))
 
-    #get all shared subsets of dimensions
+    # get all shared subsets of dimensions
     shared_subsets = vcat(
         [[i] for i in 1:ndims(AM)], #Single dimensions
         collect(intersect(AM.di.idx[[i,j]]...) for i in 1:length(AM.di.idx) for j in i+1:length(AM.di.idx)) #Shared subsets
     ) |> unique
 
-    #loop over these subsets, and check marginal totals are equal in every array margin where they appear
+    # loop over these subsets, and check marginal totals are equal in every array margin where they appear
     aligned_margins = align_margins(AM)
     check = true
     for dd in shared_subsets

--- a/src/DimIndices.jl
+++ b/src/DimIndices.jl
@@ -22,9 +22,12 @@ struct DimIndices
     idx::Vector{Vector{Int}}
     # inner constructor checking uniqueness & completeness
     function DimIndices(idx::Vector{Vector{Int}})
-        # uniqueness
-        if !allunique(vcat(idx...)) 
-            error("Some dimensions were duplicated.")
+        # uniqueness between sets of indices 
+        if !allunique(sort.(idx))
+            error("Some sets of dimensions were duplicated, e.g. [[1,2], [2,1]].")
+        # uniqueness within sets of indices
+        elseif !all(allunique, idx)
+            error("Some dimensions were duplicated within a set, e.g. [[2,1,2], [3]].")
         end
         # completeness
         D = maximum(maximum.(idx))

--- a/src/ProportionalFitting.jl
+++ b/src/ProportionalFitting.jl
@@ -2,7 +2,7 @@ module ProportionalFitting
 
 export
     DimIndices,
-    ArrayMargins, isconsistent, proportion_transform,
+    ArrayMargins, isconsistent, proportion_transform, check_margin_totals,
     ArrayFactors,
     ipf
 

--- a/src/ProportionalFitting.jl
+++ b/src/ProportionalFitting.jl
@@ -2,7 +2,7 @@ module ProportionalFitting
 
 export
     DimIndices,
-    ArrayMargins, isconsistent, proportion_transform, check_margin_totals,
+    ArrayMargins, isconsistent, proportion_transform, align_arrays, margin_totals_match,
     ArrayFactors,
     ipf
 

--- a/src/ipf.jl
+++ b/src/ipf.jl
@@ -73,6 +73,7 @@ function ipf(X::AbstractArray{<:Real}, mar::ArrayMargins; maxiter::Int = 1000, t
     di = mar.di
     mar_seed = ArrayMargins(X, di)
     fac = [mar.am[i] ./ mar_seed.am[i] for i in 1:J]
+    n_dims = ndims(mar)
     X_prod = copy(X)
     
     # start iteration
@@ -85,7 +86,7 @@ function ipf(X::AbstractArray{<:Real}, mar::ArrayMargins; maxiter::Int = 1000, t
         for j in 1:J # loop over margin elements
             # get complement dimensions
             notj = setdiff(1:J, j)
-            notd = di[notj]
+            notd = setdiff(1:n_dims, di[j])
 
             # create X multiplied by complement factors
             for k in 1:(J-1) # loop over complement dimensions
@@ -113,7 +114,7 @@ function ipf(X::AbstractArray{<:Real}, mar::ArrayMargins; maxiter::Int = 1000, t
             end
 
             # then we compute the margin by summing over all complement dimensions
-            complement_dims = Tuple(vcat(notd...))
+            complement_dims = Tuple(notd)
             cur_sum = dropdims(sum(X_prod; dims = complement_dims), dims = complement_dims)
             if !issorted(di[j])
                 # reorder if necessary for elementwise division

--- a/src/ipf.jl
+++ b/src/ipf.jl
@@ -51,19 +51,19 @@ function ipf(X::AbstractArray{<:Real}, mar::ArrayMargins; maxiter::Int = 1000, t
         throw(DimensionMismatch("The number of margins ($(ndims(mar))) needs to equal ndims(X) = $(ndims(X))."))
     end
     array_size = size(X)
-    if array_size != size(mar) #calling size(mar) implicitly checks dimension sizes between arrays
+    if array_size != size(mar) 
         throw(DimensionMismatch("The size of the margins $(size(mar)) needs to equal size(X) = $array_size."))
     end
 
     # margin consistency checks
-    if (!isconsistent(mar; tol = tol)) || !check_margin_totals(mar; tol = tol)
+    if (!isconsistent(mar; tol = tol)) || !margin_totals_match(mar; tol = tol)
         # transform to proportions
         @info "Inconsistent target margins, converting `X` and `mar` to proportions." 
         X /= sum(X)
         mar = proportion_transform(mar)
 
         #recheck proportions across margins that appear more than once
-        if !check_margin_totals(mar; tol = tol)
+        if !margin_totals_match(mar; tol = tol)
             throw(DimensionMismatch("Margin proportions inconsistent across dimensions"))
         end
     end

--- a/src/ipf.jl
+++ b/src/ipf.jl
@@ -51,16 +51,21 @@ function ipf(X::AbstractArray{<:Real}, mar::ArrayMargins; maxiter::Int = 1000, t
         throw(DimensionMismatch("The number of margins ($(ndims(mar))) needs to equal ndims(X) = $(ndims(X))."))
     end
     array_size = size(X)
-    if array_size != size(mar)
+    if array_size != size(mar) #calling size(mar) implicitly checks dimension sizes between arrays
         throw(DimensionMismatch("The size of the margins $(size(mar)) needs to equal size(X) = $array_size."))
     end
 
-    # margin consistency check
-    if !isconsistent(mar; tol = tol)
+    # margin consistency checks
+    if (!isconsistent(mar; tol = tol)) || !check_margin_totals(mar; tol = tol)
         # transform to proportions
-        @info "Inconsistent target margins, converting `X` and `mar` to proportions. Margin totals: $(sum.(mar.am))" 
+        @info "Inconsistent target margins, converting `X` and `mar` to proportions." 
         X /= sum(X)
         mar = proportion_transform(mar)
+
+        #recheck proportions across margins that appear more than once
+        if !check_margin_totals(mar; tol = tol)
+            throw(DimensionMismatch("Margin proportions inconsistent across dimensions"))
+        end
     end
 
     # initialization (simplified first iteration)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -88,8 +88,7 @@ end
     target_13 = fill(3, (2,4))
     target_23 = fill(2, (3,4))
     di = DimIndices([[1,3], [2,1]]) #incorrect should be [[1,3], [2,3]]
-    m = ArrayMargins([target_13, target_23], di)
-    @test_throws DimensionMismatch size(m)
+    @test_throws DimensionMismatch m = ArrayMargins([target_13, target_23], di)
 end
 
 @testset "ArrayFactors" begin
@@ -132,8 +131,7 @@ end
     di = DimIndices([[1, 2], [4,2,3], [3,1]])
     f5 = reshape(10:13, 2, 2)
     # test error
-    fac8 = ArrayFactors([f2, f4, f2'], di)
-    @test_throws DimensionMismatch size(fac8)
+    @test_throws DimensionMismatch fac8 = ArrayFactors([f2, f4, f2'], di)
     # test correct version
     fac9 = ArrayFactors([f2, f4, f5], di)
     @test size(fac9) == (2,3,2,2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -67,22 +67,22 @@ end
     @test isconsistent(mar6)
     mar6_p = proportion_transform(mar6)
     @test sum.(mar6_p.am) ≈ fill(1., 4)
-    @test check_margin_totals(mar6)
+    @test margin_totals_match(mar6)
 
     # Check we can catch margin inconsistency
     mar7 = deepcopy(mar6)
     mar7.am[2][1,2,4] += 1 #augment one value by one
     @test !isconsistent(mar7)
-    @test_warn r"Margin totals do not match" check_margin_totals(mar7)
+    @test_warn r"Margin totals do not match" margin_totals_match(mar7)
 
     # Check we can achieve proportion consistency even if margin totals are not consistent
     mar8 = deepcopy(mar6)
     mar8.am[1] .*= 2.5 #scale
     @test !isconsistent(mar8; tol = sqrt(eps(Float64)))
-    @test_warn r"Margin totals do not match" check_margin_totals(mar8)
+    @test_warn r"Margin totals do not match" margin_totals_match(mar8)
     mar8_p = proportion_transform(mar8)
     @test isconsistent(mar8_p; tol = sqrt(eps(Float64)))
-    @test_nowarn check_margin_totals(mar8_p; tol = sqrt(eps(Float64)))
+    @test_nowarn margin_totals_match(mar8_p; tol = sqrt(eps(Float64)))
 
     # Test we catch mismatched lengths of repeated dimensions
     target_13 = fill(3, (2,4))


### PR DESCRIPTION
This is a PR addressing issue #18 . I believe the problem can be addressed without changing any of the maths. However, it turned out that:

* the uniqueness of dimensions in `DimIndices` objects was implicitly assumed by a lot of downstream methods, which needed to be rewritten
* it's also necessary to perform more checks on `ArrayMargins` objects, since there is a lot of potential for issues when dimensions are repeated inconsistently

Both of those made this rather a large PR, and I've broken it up into several commits to try and make things clearer. 

While it implements the required functionality and passes the tests, I'm sure the code could be improved, and I'm more than happy to work on this further - but I thought it had reached a point where any feedback would be very welcome.