### PR TITLE
add efficient in-place adjust!() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,12 @@ See the full documentation and getting started [here](https://vankesteren.github
 using ProportionalFitting
 
 # matrix to be adjusted
-X = [40 30 20 10; 35 50 100 75; 30 80 70 120; 20 30 40 50]
+X = [
+  40 30  20  10
+  35 50 100  75
+  30 80  70 120
+  20 30  40  50
+]
 
 # target margins
 u = [150, 300, 400, 150]

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -354,9 +354,9 @@ version = "1.11.0"
 
 [[deps.Distributions]]
 deps = ["AliasTables", "FillArrays", "LinearAlgebra", "PDMats", "Printf", "QuadGK", "Random", "SpecialFunctions", "Statistics", "StatsAPI", "StatsBase", "StatsFuns"]
-git-tree-sha1 = "6d8b535fd38293bc54b88455465a1386f8ac1c3c"
+git-tree-sha1 = "3e6d038b77f22791b8e3472b7c633acea1ecac06"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
-version = "0.25.119"
+version = "0.25.120"
 
     [deps.Distributions.extensions]
     DistributionsChainRulesCoreExt = "ChainRulesCore"
@@ -374,10 +374,10 @@ uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 version = "0.9.4"
 
 [[deps.Documenter]]
-deps = ["ANSIColoredPrinters", "AbstractTrees", "Base64", "CodecZlib", "Dates", "DocStringExtensions", "Downloads", "Git", "IOCapture", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "MarkdownAST", "Pkg", "PrecompileTools", "REPL", "RegistryInstances", "SHA", "TOML", "Test", "Unicode"]
-git-tree-sha1 = "b7af952d4701252dc45d3b0025693e9cb4dedcd8"
+deps = ["ANSIColoredPrinters", "AbstractTrees", "Base64", "CodecZlib", "Dates", "DocStringExtensions", "Downloads", "Git", "IOCapture", "InteractiveUtils", "JSON", "Logging", "Markdown", "MarkdownAST", "Pkg", "PrecompileTools", "REPL", "RegistryInstances", "SHA", "TOML", "Test", "Unicode"]
+git-tree-sha1 = "22ca291bada1e8af75dcb5b41f9e1d2da91c2986"
 uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-version = "1.10.2"
+version = "1.11.0"
 
 [[deps.Downloads]]
 deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
@@ -473,10 +473,10 @@ uuid = "38e38edf-8417-5370-95a0-9cbb8c7f171a"
 version = "1.9.0"
 
 [[deps.Git]]
-deps = ["Git_jll"]
-git-tree-sha1 = "04eff47b1354d702c3a85e8ab23d539bb7d5957e"
+deps = ["Git_jll", "JLLWrappers", "OpenSSH_jll"]
+git-tree-sha1 = "2230a9cc32394b11a3b3aa807a382e3bbab1198c"
 uuid = "d7ba0133-e1db-5d97-8f8c-041e4b3a1eb2"
-version = "1.3.1"
+version = "1.4.0"
 
 [[deps.Git_jll]]
 deps = ["Artifacts", "Expat_jll", "JLLWrappers", "LibCURL_jll", "Libdl", "Libiconv_jll", "OpenSSL_jll", "PCRE2_jll", "Zlib_jll"]
@@ -815,6 +815,12 @@ deps = ["Artifacts", "Libdl"]
 uuid = "05823500-19ac-5b8b-9628-191a04bc5112"
 version = "0.8.5+0"
 
+[[deps.OpenSSH_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "OpenSSL_jll", "Zlib_jll"]
+git-tree-sha1 = "cb7acd5d10aff809b4d0191dfe1956c2edf35800"
+uuid = "9bd350c2-7e96-507f-8002-3f2e150b4e1b"
+version = "10.0.1+0"
+
 [[deps.OpenSSL_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
 git-tree-sha1 = "9216a80ff3682833ac4b733caa8c00390620ba5d"
@@ -839,9 +845,9 @@ version = "10.42.0+1"
 
 [[deps.PDMats]]
 deps = ["LinearAlgebra", "SparseArrays", "SuiteSparse"]
-git-tree-sha1 = "0e1340b5d98971513bddaa6bbed470670cebbbfe"
+git-tree-sha1 = "f07c06228a1c670ae4c87d1276b92c7c597fdda0"
 uuid = "90014a1f-27ba-587c-ab20-58faa44d9150"
-version = "0.11.34"
+version = "0.11.35"
 
 [[deps.Parsers]]
 deps = ["Dates", "PrecompileTools", "UUIDs"]
@@ -898,9 +904,9 @@ uuid = "92933f4c-e287-5a05-a399-4b506db050ca"
 version = "1.10.4"
 
 [[deps.ProportionalFitting]]
-git-tree-sha1 = "7061e4dde3a73b2f0c974e0bf35ed2bffda9b39e"
+path = ".."
 uuid = "3c40d49d-59d4-4b5d-adaa-75a7fbc8c64f"
-version = "0.3.0"
+version = "0.4.0"
 
 [[deps.PtrArrays]]
 git-tree-sha1 = "1d36ef11a9aaf1e8b74dacc6a731dd1de8fd493d"

--- a/src/ArrayFactors.jl
+++ b/src/ArrayFactors.jl
@@ -167,6 +167,8 @@ function adjust!(X::AbstractArray, AF::ArrayFactors)
     for d in 1:length(AF)
         X .*= aligned_factors[d]
     end
+
+    return X
 end
 
 # method to align all arrays so each has dimindices 1:ndims(AM)

--- a/src/ProportionalFitting.jl
+++ b/src/ProportionalFitting.jl
@@ -7,6 +7,7 @@ export DimIndices,
     align_margins,
     margin_totals_match,
     ArrayFactors,
+    adjust!,
     ipf
 
 include("DimIndices.jl")

--- a/src/ipf.jl
+++ b/src/ipf.jl
@@ -21,7 +21,7 @@ If decreasing memory usage is a concern, it is possible to set `precision` to be
 see also: [`ArrayFactors`](@ref), [`ArrayMargins`](@ref)
 
 # Arguments
-- `X::AbstractArray{<:Real}`: Array to be adjusted
+- `X::AbstractArray{<:Real}`: Seed array to be adjusted
 - `mar::ArrayMargins`: Target margins as an ArrayMargins object
 - `maxiter::Int=1000`: Maximum number of iterations
 - `precision::DataType=Float64`: The numeric precision to which calculations are
@@ -38,17 +38,27 @@ Factors for 2D array:
     [1]: [0.9986403503185242, 0.8833622306385376, 1.1698911437112522, 0.8895042701910321]
     [2]: [1.616160156063788, 1.5431801747375655, 1.771623700829941, 0.38299396265192226]
 
-julia> Z = Array(AF) .* X
+julia> X_adj = X .* Array(AF)
 4×4 Matrix{Float64}:
  64.5585   46.2325   35.3843   3.82473
  49.9679   68.1594  156.499   25.3742
  56.7219  144.428   145.082   53.7673
  28.7516   41.18     63.0347  17.0337
 
-julia> ArrayMargins(Z)
+julia> ArrayMargins(X_adj)
 Margins of 2D array:
   [1]: [150.0000000009452, 299.99999999962523, 399.99999999949796, 149.99999999993148]
   [2]: [200.0, 299.99999999999994, 399.99999999999994, 99.99999999999997]
+```
+
+If you have a large seed array to be adjusted, it is much more memory-efficient and much
+faster to directly run the in-place `adjust!()` method to avoid copying the array:
+
+```julia-repl
+julia> X = rand(500, 100, 20) .* 10
+julia> AM = ArrayMargins(X + rand(500, 100, 20) ./ 10)
+julia> AF = ipf(X, AM)
+julia> adjust!(X, AF)
 ```
 """
 function ipf(

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -91,9 +91,6 @@ end
     target_23 = fill(2, (3, 4))
     di = DimIndices([[1, 3], [2, 1]]) #incorrect should be [[1,3], [2,3]]
     @test_throws DimensionMismatch m = ArrayMargins([target_13, target_23], di)
-
-    # Test conversion method
-    @test all(x -> eltype(x) === Float32, convert(Float32, mar6).am)
 end
 
 @testset "ArrayFactors" begin
@@ -110,6 +107,27 @@ end
 
     fac3 = ArrayFactors([[4, 5], [1, 2, 3]], DimIndices([2, 1]))
     @test Array(fac) == Array(fac3)
+
+    # adjust method
+    X = [
+        1 2
+        3 4
+        5 6
+    ]
+
+    @test X .* Array(fac3) == [
+        4 10
+        24 40
+        60 90
+    ]
+
+    adjust!(X, fac3)
+
+    @test X == [
+        4 10
+        24 40
+        60 90
+    ]
 
     # multidimensional madness
     di = DimIndices([1, [2, 3], 4, [5, 6, 7]])
@@ -172,19 +190,6 @@ end
     X_prime = Array(AF) .* X
     AM = ArrayMargins(X_prime)
     @test AM.am ≈ m.am
-
-    # Test we can set precision returns
-    AF_32 = ipf(X, m; precision=Float32)
-    @test all(x -> eltype(x) === Float32, AF_32.af)
-
-    # Test converting to precision does not error
-    X_32 = convert.(Float32, X)
-    m_32 = convert(Float32, m)
-    AF_64 = ipf(X_32, m_32; precision=Float64)
-    @test all(x -> eltype(x) === Float64, AF_64.af)
-
-    # Test the argument error
-    @test_throws ArgumentError ipf(X, m; precision=Int64)
 end
 
 @testset "Multidimensional ipf" begin


### PR DESCRIPTION
fixes #19

NB: This only works for AbstractFloat seed arrays, or Integer arrays if the ArrayFactors themselves are integers (this is uncommon)

Also updated docs to refer to `adjust!()`.

To do:
- [x] Add explicit tests (implicit tests already in `Array(AF)`)
- [ ] ~Maybe update documentation to include a section on this (in index.md)~