### PR TITLE
Pre-compute reshaping in ipf() loop

### DIFF
--- a/src/ArrayFactors.jl
+++ b/src/ArrayFactors.jl
@@ -108,6 +108,11 @@ end
 Base.size(AF::ArrayFactors) = AF.size
 Base.length(AF::ArrayFactors) = length(AF.af)
 
+# method to align all arrays so each has dimindices 1:ndims(AM)
+function align_margins(AF::ArrayFactors{T})::Vector{Array{T}} where T
+    align_margins(AF.af, AF.di, AF.size)
+end
+
 """
     Array(AF::ArrayFactors{T})
 
@@ -139,19 +144,10 @@ julia> Array(fac)
 """
 function Base.Array(AF::ArrayFactors{T}) where {T}
     D = length(AF.di)
-    asize = size(AF)
-    M = ones(T, asize)
+    M = ones(T, size(AF))
+    aligned_factors = align_margins(AF)
     for d in 1:D
-        idx = AF.di.idx[d]
-        af = AF.af[d]
-        if !issorted(idx)
-            sp = sortperm(idx)
-            idx = idx[sp]
-            af = permutedims(af, sp)
-        end
-        dims = [idx...]
-        shp = ntuple(i -> i ∉ dims ? 1 : asize[popfirst!(dims)], ndims(AF.di))
-        M .*= reshape(af, shp)
+        M .*= aligned_factors[d]
     end
     return M
 end

--- a/src/ArrayMargins.jl
+++ b/src/ArrayMargins.jl
@@ -129,24 +129,8 @@ Base.length(AM::ArrayMargins) = length(AM.am)
 Base.ndims(AM::ArrayMargins) = length(AM.size)
 
 # method to align all arrays so each has dimindices 1:ndims(AM)
-function align_margins(AM::ArrayMargins{T})::Vector{Array{T}} where {T}
-    aligned_margins = Vector{Array{T}}()
-
-    for i in 1:length(AM)
-        cur_idx = AM.di.idx[i]
-        cur_arr = AM.am[i]
-        # sort dimensions if necessary
-        if !issorted(cur_idx)
-            sp = sortperm(cur_idx)
-            cur_idx = cur_idx[sp]
-            cur_arr = permutedims(cur_arr, sp)
-        end
-        # create correct shape for elementwise operations
-        shp = ntuple(i -> i ∉ cur_idx ? 1 : size(AM)[i], ndims(AM))
-        push!(aligned_margins, reshape(cur_arr, shp))
-    end
-
-    return aligned_margins
+function align_margins(AM::ArrayMargins{T})::Vector{Array{T}} where T
+    align_margins(AM.am, AM.di, AM.size)
 end
 
 # methods for consistency of margins

--- a/src/ProportionalFitting.jl
+++ b/src/ProportionalFitting.jl
@@ -4,7 +4,7 @@ export DimIndices,
     ArrayMargins,
     isconsistent,
     proportion_transform,
-    align_arrays,
+    align_margins,
     margin_totals_match,
     ArrayFactors,
     ipf
@@ -12,6 +12,7 @@ export DimIndices,
 include("DimIndices.jl")
 include("ArrayMargins.jl")
 include("ArrayFactors.jl")
+include("utils.jl")
 include("ipf.jl")
 
 end # module

--- a/src/ipf.jl
+++ b/src/ipf.jl
@@ -141,8 +141,12 @@ function ipf(
     # return factors to original margin shape
     reshaped_factors = map(1:J) do j
         reshaped_fac = dropdims(fac[j]; dims=complement_dims[j])
-        sp = sortperm(sortperm(di[j]))
-        permutedims(reshaped_fac, sp)
+        if !issorted(di[j])
+            sp = sortperm(sortperm(di[j]))
+            permutedims(reshaped_fac, sp)
+        else
+            reshaped_fac
+        end
     end
 
     return ArrayFactors(reshaped_factors, di)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,6 +1,3 @@
-# dict methods for future reference
-Base.Dict(AM::ArrayMargins) = Dict(AM.di[i] => AM.am[i] for i in 1:length(AM))
-Base.Dict(AF::ArrayFactors) = Dict(AF.di[i] => AF.af[i] for i in 1:length(AF))
 
 # method to align margins according to the size of a larger array
 function align_margins(arr::AbstractArray, idx::Vector{Int}, shape::Tuple)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -6,7 +6,7 @@ Base.Dict(AF::ArrayFactors) = Dict(AF.di[i] => AF.af[i] for i in 1:length(AF))
 function align_margins(arr::AbstractArray, idx::Vector{Int}, shape::Tuple)
     # sort dimensions if necessary
     sp = sortperm(idx)
-    permuted_arr = permutedims(arr, sp)
+    permuted_arr = PermutedDimsArray(arr, sp) # use a view unlike permutedims()
     # create correct shape for elementwise operations
     shp = ntuple(i -> i ∉ idx ? 1 : shape[i], length(shape))
     return reshape(permuted_arr, shp)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,0 +1,20 @@
+# dict methods for future reference
+Base.Dict(AM::ArrayMargins) = Dict(AM.di[i] => AM.am[i] for i in 1:length(AM))
+Base.Dict(AF::ArrayFactors) = Dict(AF.di[i] => AF.af[i] for i in 1:length(AF))
+
+# method to align margins according to the size of a larger array
+function align_margins(arr::AbstractArray, idx::Vector{Int}, shape::Tuple)
+    # sort dimensions if necessary
+    sp = sortperm(idx)
+    permuted_arr = permutedims(arr, sp)
+    # create correct shape for elementwise operations
+    shp = ntuple(i -> i ∉ idx ? 1 : shape[i], length(shape))
+    return reshape(permuted_arr, shp)
+end
+
+# method to align all arrays so each has dimindices 1:length(shape)
+function align_margins(A::Vector{<:AbstractArray}, DI::DimIndices, shape::Tuple)
+    map(A, DI.idx) do arr, idx
+        align_margins(arr, idx, shape)
+    end
+end


### PR DESCRIPTION
This PR adjusts the `ipf()` function to pre-compute the array reshaping rather than doing it in the inner loop, to address issue #25. There are three commits:

1. Moving the `align_margins()` logic out of *src/ArrayFactors.jl* and into a centralised location (*src/utils.jl* - re-created since 0.4.0) where all package scripts can access it
2. Making minimal adjustments to the `ipf()` function to use `align_margins()`
3. Further simplifications to `ipf()` taking advantage of those changes