### PR TITLE
Set precision of ipf

### DIFF
--- a/src/ArrayMargins.jl
+++ b/src/ArrayMargins.jl
@@ -139,7 +139,7 @@ function align_margins(AM::ArrayMargins{T})::Vector{Array{T}} where T
 end
 
 # methods for consistency of margins
-function isconsistent(AM::ArrayMargins; tol = √eps(Float64))
+function isconsistent(AM::ArrayMargins; tol = 1e-10)
     marsums = sum.(AM.am)
     return (maximum(marsums) - minimum(marsums)) < tol
 end
@@ -149,7 +149,7 @@ function proportion_transform(AM::ArrayMargins)
     return ArrayMargins(mar, AM.di)
 end
 
-function margin_totals_match(AM::ArrayMargins; tol = √eps(Float64))
+function margin_totals_match(AM::ArrayMargins; tol = 1e-10)
 
     # get all shared subsets of dimensions
     shared_subsets = unique(vcat(

--- a/src/ArrayMargins.jl
+++ b/src/ArrayMargins.jl
@@ -128,23 +128,28 @@ Base.size(AM::ArrayMargins) = AM.size
 Base.length(AM::ArrayMargins) = length(AM.am)
 Base.ndims(AM::ArrayMargins) = length(AM.size)
 
+function Base.convert(T::DataType, AM::ArrayMargins)::ArrayMargins{T}
+    new_margins = [convert.(T, arr) for arr in AM.am]
+    return ArrayMargins(new_margins, AM.di)
+end
+
 # method to align all arrays so each has dimindices 1:ndims(AM)
 function align_margins(AM::ArrayMargins{T})::Vector{Array{T}} where T
     align_margins(AM.am, AM.di, AM.size)
 end
 
 # methods for consistency of margins
-function isconsistent(AM::ArrayMargins; tol::Float64=eps(Float64))
+function isconsistent(AM::ArrayMargins; tol = √eps(Float64))
     marsums = sum.(AM.am)
     return (maximum(marsums) - minimum(marsums)) < tol
 end
 
 function proportion_transform(AM::ArrayMargins)
-    mar = convert.(Array{Float64}, AM.am) ./ sum.(AM.am)
+    mar = AM.am ./ sum.(AM.am)
     return ArrayMargins(mar, AM.di)
 end
 
-function margin_totals_match(AM::ArrayMargins; tol::Float64=eps(Float64))
+function margin_totals_match(AM::ArrayMargins; tol = √eps(Float64))
 
     # get all shared subsets of dimensions
     shared_subsets = unique(vcat(
@@ -159,7 +164,7 @@ function margin_totals_match(AM::ArrayMargins; tol::Float64=eps(Float64))
     aligned_margins = align_margins(AM)
     check = true
     for dd in shared_subsets
-        margin_totals = Vector{Array{Float64}}()
+        margin_totals = Vector{Array}()
         for i in 1:length(AM.am)
             if issubset(dd, AM.di.idx[i])
                 complement_dims = setdiff(1:ndims(AM), dd)

--- a/src/ipf.jl
+++ b/src/ipf.jl
@@ -121,7 +121,7 @@ function ipf(
                 cur_fac = fac[notj[k]] # get current factor
                 # perform elementwise multiplication
                 if k == 1
-                    X_prod = X_p .* cur_fac
+                    X_prod .= X_p .* cur_fac
                 else
                     X_prod .*= cur_fac
                 end

--- a/src/ipf.jl
+++ b/src/ipf.jl
@@ -6,7 +6,7 @@
 
 Perform iterative proportional fitting (factor method). The array (X) can be
 any number of dimensions, and the margins can be multidimensional as well. 
-If only the margins are given, then the seed matrix `X` is assumed
+If only the margins are given, then the seed array `X` is assumed
 to be an array filled with ones of the correct size and element type.
 
 If the margins are not an ArrayMargins object, they will be coerced to this type.
@@ -14,13 +14,19 @@ If the margins are not an ArrayMargins object, they will be coerced to this type
 This function returns the update matrix as an ArrayFactors object. To compute
 the updated matrix, use `Array(result) .* X` (see examples).
 
+If decreasing memory usage is a concern, it is possible to set `precision` to be lower
+    than Float64. It is also possible to decrease memory usage (by up to almost 50%) by
+    supplying `X` as an an object of type `Array{precision}`.
+
 see also: [`ArrayFactors`](@ref), [`ArrayMargins`](@ref)
 
 # Arguments
 - `X::AbstractArray{<:Real}`: Array to be adjusted
 - `mar::ArrayMargins`: Target margins as an ArrayMargins object
 - `maxiter::Int=1000`: Maximum number of iterations
-- `tol::Float64=1e-10`: Factor change tolerance for convergence
+- `precision::DataType=Float64`: The numeric precision to which calculations are
+    carried out. Note that there is no bounds checking, however. Must be <:AbstractFloat.
+- `tol=√eps(precision)`: Factor change tolerance for convergence
 
 # Examples
 ```julia-repl
@@ -50,7 +56,7 @@ function ipf(
 )
     # convert to specified precision
     if !(precision <: AbstractFloat)
-        throw(ArgumentError("Argument `precision` must be a subtype of AbstractFloat such as Float64"))
+        throw(ArgumentError("Argument `precision` must be a subtype of AbstractFloat, such as Float64."))
     end
 
     tol = √eps(precision)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -91,6 +91,9 @@ end
     target_23 = fill(2, (3, 4))
     di = DimIndices([[1, 3], [2, 1]]) #incorrect should be [[1,3], [2,3]]
     @test_throws DimensionMismatch m = ArrayMargins([target_13, target_23], di)
+
+    # Test conversion method
+    @test all(x -> eltype(x) === Float32, convert(Float32, mar6).am)
 end
 
 @testset "ArrayFactors" begin
@@ -169,6 +172,19 @@ end
     X_prime = Array(AF) .* X
     AM = ArrayMargins(X_prime)
     @test AM.am ≈ m.am
+
+    # Test we can set precision returns
+    AF_32 = ipf(X, m; precision=Float32)
+    @test all(x -> eltype(x) === Float32, AF_32.af)
+
+    # Test converting to precision does not error
+    X_32 = convert.(Float32, X)
+    m_32 = convert(Float32, m)
+    AF_64 = ipf(X_32, m_32; precision=Float64)
+    @test all(x -> eltype(x) === Float64, AF_64.af)
+
+    # Test the argument error
+    @test_throws ArgumentError ipf(X, m; precision=Int64)
 end
 
 @testset "Multidimensional ipf" begin


### PR DESCRIPTION
This PR allows setting the precision of the `ipf()` calculation. This firstly allows saving memory with lower-precision calculations, but secondly and much more importantly standardises the main variables in the `ipf()` function as `Float64` by default. That in turn allows using broadcast assignment in the main ipf loop in the line `X_prod .= X .* cur_fac`, giving a large memory saving. This partially addresses #27, though `ipf()` is still type unstable more widely.

Benchmarks:
```julia
X = reshape(rand(1:100, 20_000_000), 200, 20, 25, 20, 10) #size is ~152Mb
Y = reshape(rand(1:50, 20_000_000), 200, 20, 25, 20, 10) + X
di = DimIndices([[1, 4], [5, 2, 3], [5,4,1], [2,1]])
m = ArrayMargins(Y, di)

# main
AF = ipf(X, m)
b1 = @benchmark AF = ipf(X, m)  # Allocates ~3.14 Gb

# this PR
AF = ipf(X, m)
b2 = @benchmark AF = ipf(X, m) # Allocates ~317 Mb

judge(median(b2), median(b1))

BenchmarkTools.TrialJudgement: 
  time:   -23.51% => improvement (5.00% tolerance)
  memory: -90.16% => improvement (1.00% tolerance)

# this PR, showing memory saving with type conversion
X_64 = convert(Array{Float64}, X) # Same size as X
AF = ipf(X_64, m)
b3 = @benchmark AF = ipf(X_64, m) # Allocates ~164 Mb

judge(median(b3), median(b2))

BenchmarkTools.TrialJudgement: 
  time:   -2.13% => invariant (5.00% tolerance)
  memory: -48.19% => improvement (1.00% tolerance)
```