### PR TITLE
Faster method for convergence

### DIFF
--- a/src/ipf.jl
+++ b/src/ipf.jl
@@ -141,7 +141,7 @@ function ipf(
         end
 
         # convergence check
-        crit = maximum(broadcast(x -> maximum(abs.(x)), fac - oldfac))
+        crit = @inbounds maximum(maximum(abs.(fac[i] .- oldfac[i])) for i in eachindex(fac))
         if crit < tol_p
             break
         end


### PR DESCRIPTION
A minor change, modifying the method used to calculate the criterion calculation when testing convergence, avoiding the use of `broadcast`. A benchmark:

```julia
fac = [rand(10, 20, 30) for _ in 1:5];
oldfac = [rand(10, 20, 30) for _ in 1:5];
function crit_old(x, y)
    return maximum(broadcast(_x -> maximum(abs.(_x)), x - y))
end
function crit_new(x, y)
    return @inbounds maximum(maximum(abs.(x[i] .- y[i])) for i in eachindex(x))
end

b1 = @benchmark crit_old(fac, oldfac)
b2 = @benchmark crit_new(fac, oldfac)
judge(median(b2), median(b1))

BenchmarkTools.TrialJudgement: 
  time:   -35.05% => improvement (5.00% tolerance)
  memory: -50.02% => improvement (1.00% tolerance)
 ```